### PR TITLE
docs(seax): campaign-level message_variables in auto_dialer tutorial

### DIFF
--- a/content/en/SeaX/auto_dialer_voice_campaigns.md
+++ b/content/en/SeaX/auto_dialer_voice_campaigns.md
@@ -317,6 +317,154 @@ Response:
 }
 ```
 
+## Personalizing the Call
+
+The AI agent's starting message can be personalized with **merge fields** —
+placeholders written in single curly braces, e.g. `{name}`. When a call is placed,
+every `{placeholder}` in the message is replaced _before_ the agent speaks.
+
+| Placeholder    | Where the value comes from                                                       | Example                    |
+| -------------- | -------------------------------------------------------------------------------- | -------------------------- |
+| `{name}`       | The contact's `name` (always)                                                    | `Mary`                     |
+| `{phone}`      | The contact's `phone` (always)                                                   | `+6591112222`              |
+| `{your_field}` | The campaign's `message_variables` **or** the contact's `contact_field_data`     | `{event_name}` → `Pilates` |
+
+You do **not** need to pre-define custom fields anywhere — any key you supply
+becomes available as `{key}`.
+
+### Two places to supply custom values
+
+|                     | Campaign-level — `message_variables`                                   | Per-contact — `contact_field_data`              |
+| ------------------- | ---------------------------------------------------------------------- | ----------------------------------------------- |
+| Where it's set      | On the **campaign** (one value for the whole campaign)                 | On each **contact**                             |
+| Use when            | The value is the **same for everyone** (e.g. the event being reminded) | The value **differs per person**                |
+| Touches contacts?   | No — contacts stay unchanged                                           | Yes — you store/update the value on each contact |
+
+You can use either or both. If the same key is set in both places,
+**`message_variables` wins**. `{name}` / `{phone}` always come from the contact
+and can never be overridden.
+
+> **⚠️ Outbound only.** Merge-field substitution applies to the **outbound**
+> starting message (the campaign `message`, or the agent's
+> `outbound_starting_message`). The **inbound** pick-up message
+> (`inbound_pick_up_message`) is **not** personalized with `contact_field_data` —
+> inbound calls are answered with the message exactly as configured.
+
+### Substitution rules
+
+- **Case-insensitive.** `{Event_Name}`, `{event_name}`, and `{EVENT_NAME}` all
+  match a `contact_field_data` key of `event_name`.
+- **Missing values are left as-is.** If a placeholder has no matching value for a
+  contact, the literal text (e.g. `{event_location}`) stays in the message — and
+  the agent will read it aloud. **Always provide every placeholder used in your
+  template for every contact you call.**
+- Values are inserted as plain text.
+
+For the common case — one event reminded to many people — follow Steps 1 → 2 → 3
+below. (Per-contact values are an optional add-on, Step 1b.)
+
+### Step 1 — Prepare your contacts
+
+Create your contacts with just `name` and `phone`. You only store custom values
+on the contact if they **differ per person** (see Step 1b).
+
+Single contact:
+
+```bash
+curl -X POST \
+  'https://seax.seasalt.ai/seax-api/api/v1/workspace/3fa85f64-5717-4562-b3fc-2c963f66afa6/contacts' \
+  -H 'Content-Type: application/json' \
+  -H 'X-API-Key: <your_api_key>' \
+  -d '{ "name": "Mary", "phone": "+6591112222" }'
+```
+
+The response includes the contact `id` — collect it to target the contact in the
+campaign via `addition_contact_ids`.
+
+Bulk (CSV import) — give everyone the same label so you can target them together:
+
+```bash
+# contacts.csv
+name,phone,whatsapp,labels
+Mary,+6591112222,,reminders_2026_06
+John,+6593334444,,reminders_2026_06
+```
+
+```bash
+curl -X POST \
+  'https://seax.seasalt.ai/seax-api/api/v1/workspace/3fa85f64-5717-4562-b3fc-2c963f66afa6/import_contacts?duplicate_strategy=merge' \
+  -H 'X-API-Key: <your_api_key>' \
+  -F 'file=@contacts.csv;type=text/csv'
+```
+
+`name` and `labels` are required (plus `phone` for voice). Target imported
+contacts in the campaign with `any_contact_label_ids` (the value from the
+`labels` column). See [Contacts &amp; Labels](../contacts_and_labels/) for the full
+import reference.
+
+#### Step 1b (optional) — per-contact values
+
+Only when a value **differs per recipient**, store it on the contact:
+
+- On `POST`/`PATCH /contacts`, add a `contact_field_data` object, e.g.
+  `"contact_field_data": { "first_language": "English" }`.
+- Or in the CSV, add **extra columns** — any column beyond
+  `name,phone,whatsapp,labels` becomes a custom field automatically (with
+  `duplicate_strategy=merge`, values are merged into existing contacts):
+
+```bash
+# contacts.csv with a per-contact field
+name,phone,whatsapp,labels,first_language
+Mary,+6591112222,,reminders_2026_06,English
+John,+6593334444,,reminders_2026_06,Malay
+```
+
+### Step 2 — Write the message template
+
+Put the placeholders in the campaign `message` (or configure them once in the
+agent's `outbound_starting_message`):
+
+```
+Good morning {name}, a reminder about {event_name} coming up {event_time} at {event_location}. Will you be attending?
+```
+
+### Step 3 — Create the campaign with the event variables
+
+Send the event values **once** as `message_variables` on the campaign — they
+apply to every recipient, and you never touched the contacts. (See
+[Create Campaign](#create-campaign) for the full request and all fields.)
+
+```jsonc
+{
+  "name": "Pilates reminder",
+  "type": "AI_AGENT",
+  "phone_ids": ["<phone_id>"],
+  "ai_agent_conversation_config_id": "<conversation_config_id>",
+  "message": "Good morning {name}, a reminder about {event_name} coming up {event_time} at {event_location}. Will you be attending?",
+  "message_variables": {
+    "event_name": "Pilates",
+    "event_location": "Main Hall",
+    "event_time": "this afternoon at 5 PM"
+  },
+  "addition_contact_ids": ["<contact_id>"],
+  "mode": "WEB",
+  "stage": "INSTANCE"
+}
+```
+
+### Result
+
+Every recipient hears the same event details (from `message_variables`); only
+`{name}` differs per person (from each contact):
+
+| Contact               | Spoken opening message                                                                                                                  |
+| --------------------- | -------------------------------------------------------------------------------------------------------------------------------------- |
+| Mary (`+6591112222`)  | "Good morning **Mary**, a reminder about **Pilates** coming up **this afternoon at 5 PM** at **Main Hall**. Will you be attending?"     |
+| John (`+6593334444`)  | "Good morning **John**, a reminder about **Pilates** coming up **this afternoon at 5 PM** at **Main Hall**. Will you be attending?"     |
+
+If you instead need different values per person, omit `message_variables` and put
+the values in each contact's `contact_field_data` (Step 1b).
+
 ## Campaign Management
 
 ### Create Campaign
@@ -339,7 +487,7 @@ Use this endpoint to trigger an outbound auto dialer voice campaign.
 | `is_timezone_aware`                  | `boolean`             | Whether the schedule is timezone aware                                | `false`                                                                                     |          |
 | `mode`                               | `string`              | Campaign execution mode                                               | `WEB`                                                                                       | ✅       |
 | `stage`                              | `string`              | Processing stage of the campaign                                      | `INSTANCE`                                                                                  | ✅       |
-| `message`                            | `string`              | Message to be delivered (used by TTS or AI agent)                     | `Hi, do you have a few minutes to take our survey?`                                         |          |
+| `message`                            | `string`              | Starting message spoken by the AI agent (or read by TTS). Supports **merge fields** such as `{name}` and any custom `contact_field_data` key — see [Personalizing the Call with Contact Fields](#personalizing-the-call-with-contact-fields). If omitted, the agent's configured `outbound_starting_message` is used. | `Good morning {name}, this is a reminder about {event_name}.`                               |          |
 | `tts_language`                       | `string`              | TTS language code                                                     | `""` (Recommended to leave as empty string to use the default configured in your workspace) |          |
 | `tts_voice`                          | `string`              | TTS voice type                                                        | `default`                                                                                   |          |
 | `audio_url`                          | `string`              | Optional audio URL (if not using TTS)                                 | `""` (Recommended to leave as empty string to use default configured on seachat)            |          |
@@ -351,6 +499,8 @@ Use this endpoint to trigger an outbound auto dialer voice campaign.
 | `overwrite_phone_recipient.receiver` | `string`              | The identifier for the new recipient.                                 | `221316ae-8a9f-4f39-b7f8-f2e756b80a63`                                                      |          |
 | `exclude_contact_ids`                | `array[string]`       | Contact IDs to exclude                                                | `["4667298e-8d5b-468e-8218-6a47925fe5f2","aa145964-6d17-488d-a9be-09a43191f329"]`           |          |
 | `any_contact_label_ids`              | `array[string]`       | Include contacts with any of these labels                             | `["dd20f7cd-03fb-4c79-9f3e-998372d1bec6"]`                                                  |          |
+| `addition_contact_ids`               | `array[string]`       | Explicit contact IDs to call, in addition to any label-based selection. Use this to target a specific list of contacts you created or looked up. | `["9362acd4-0d83-4ce9-ab0d-31834ad8bc9c"]`                                                  |          |
+| `contact_field_ids`                  | `array[string]`       | Optional. IDs of workspace contact fields to associate with the campaign — for reporting/display only. **Not required** for merge-field substitution. | `[]`                                                                                        |          |
 
 ###### Example
 

--- a/content/en/SeaX/export_conversations.md
+++ b/content/en/SeaX/export_conversations.md
@@ -42,7 +42,7 @@ include a valid API key in the request header (`X-API-Key`).
 
 - Click **Add New Key** and check `Workspace Events Notification` as the scope.
 
-- Copy the key and keep it safe. This key is required in the `X-API-KEY` header
+- Copy the key and keep it safe. This key is required in the `X-API-Key` header
   for **all requests**.
 
 ## How It Works
@@ -89,6 +89,11 @@ Notes:
 - If a `phone_number` matches **more than one** channel, the request returns
   `409` with the list of matching channels — resend with `channel_type` (or with
   the exact `channel_id`) to disambiguate.
+- The `channel_type` you send in the request is a coarse category
+  (`sms`, `whatsapp`, `messenger`, `instagram`, `line`). In the `409` response,
+  each candidate's `channel_type` is the channel's underlying detailed type
+  (for example `LOCAL` maps to `sms`, and `WHATSAPP_BUSINESS_PLATFORM` maps to
+  `whatsapp`).
 - Only one active export per channel and date range is allowed at a time; a
   duplicate request while one is still running returns `409`.
 
@@ -164,6 +169,7 @@ A phone number that matches multiple channels (`409 Conflict`):
 | Status | Reason                                                                          |
 | ------ | ------------------------------------------------------------------------------- |
 | `400`  | `start_date` is in the future, or the date format is invalid.                   |
+| `401`  | Missing or invalid `X-API-Key`.                                                 |
 | `404`  | No channel found for the given `channel_id`, or no channel for the phone number. |
 | `409`  | The phone number matches multiple channels, or an export for this channel/date range is already in progress. |
 
@@ -173,7 +179,8 @@ A phone number that matches multiple channels (`409 Conflict`):
 
 Poll an export job. While the job is running, `status` is `queued` or `started`
 and `presigned_url` is `null`. When the job is `finished`, `presigned_url`
-contains a download link valid for 24 hours.
+contains a download link valid for 24 hours. If the job `status` is `failed`,
+`presigned_url` stays `null` and `error_message` contains the failure detail.
 
 Path / Header
 

--- a/content/en/SeaX/export_conversations.md
+++ b/content/en/SeaX/export_conversations.md
@@ -82,20 +82,31 @@ Request Body: ExportConversationsRequest
 | `channel_type`       | `string` | Disambiguates a phone number shared by multiple channels (e.g. a WhatsApp and an SMS channel on the same number).           | `sms`, `whatsapp`, `messenger`, `instagram`, `line` |          |
 | `notification_email` | `string` | Email address to send the download link to when the export is ready.                                                        | `"agent@example.com"`                    |          |
 
-Notes:
+**Choosing the channel**
 
-- Provide exactly one of `channel_id` or `phone_number`. If both are omitted the
-  request is rejected.
-- If a `phone_number` matches **more than one** channel, the request returns
-  `409` with the list of matching channels — resend with `channel_type` (or with
-  the exact `channel_id`) to disambiguate.
-- The `channel_type` you send in the request is a coarse category
-  (`sms`, `whatsapp`, `messenger`, `instagram`, `line`). In the `409` response,
-  each candidate's `channel_type` is the channel's underlying detailed type
-  (for example `LOCAL` maps to `sms`, and `WHATSAPP_BUSINESS_PLATFORM` maps to
-  `whatsapp`).
-- Only one active export per channel and date range is allowed at a time; a
-  duplicate request while one is still running returns `409`.
+Identify the channel with **either** `channel_id` **or** `phone_number` —
+provide exactly one. Omitting both rejects the request.
+
+**When a phone number is shared by several channels**
+
+The same number can belong to more than one channel (for example a WhatsApp
+channel and an SMS channel that share a number). In that case `phone_number`
+alone is ambiguous and the request returns `409` with a `candidates` list. Retry
+with one of the following:
+
+- `channel_type` — the coarse category of the channel you want. Accepted values:
+  `sms`, `whatsapp`, `messenger`, `instagram`, `line`.
+- `channel_id` — the exact channel, which is unambiguous on its own.
+
+> The `channel_type` shown for each candidate in the `409` response is the
+> channel's detailed internal type (e.g. `LOCAL` or `WHATSAPP_BUSINESS_PLATFORM`),
+> which maps to the coarse value you send (`LOCAL` → `sms`,
+> `WHATSAPP_BUSINESS_PLATFORM` → `whatsapp`). You always send the coarse value.
+
+**One export at a time**
+
+Only one active export is allowed per channel and date range. Requesting another
+while one is still running returns `409`.
 
 ###### Example
 

--- a/content/en/SeaX/export_conversations.md
+++ b/content/en/SeaX/export_conversations.md
@@ -85,7 +85,8 @@ Request Body: ExportConversationsRequest
 **Choosing the channel**
 
 Identify the channel with **either** `channel_id` **or** `phone_number` —
-provide exactly one. Omitting both rejects the request.
+provide exactly one. If you omit both, the request returns `422` with the
+message `either channel_id or phone_number must be provided`.
 
 **When a phone number is shared by several channels**
 
@@ -179,10 +180,11 @@ A phone number that matches multiple channels (`409 Conflict`):
 
 | Status | Reason                                                                          |
 | ------ | ------------------------------------------------------------------------------- |
-| `400`  | `start_date` is in the future, or the date format is invalid.                   |
+| `400`  | `start_date` is in the future.                                                  |
 | `401`  | Missing or invalid `X-API-Key`.                                                 |
 | `404`  | No channel found for the given `channel_id`, or no channel for the phone number. |
 | `409`  | The phone number matches multiple channels, or an export for this channel/date range is already in progress. |
+| `422`  | Request body validation failed — e.g. neither `channel_id` nor `phone_number` provided, an invalid date format, `end_date` before `start_date`, or an invalid `phone_number` / `channel_type`. |
 
 ### 2) Get Export Job Status
 

--- a/content/en/SeaX/export_conversations.md
+++ b/content/en/SeaX/export_conversations.md
@@ -77,8 +77,8 @@ Request Body: ExportConversationsRequest
 | -------------------- | -------- | --------------------------------------------------------------------------------------------------------------------------- | ---------------------------------------- | -------- |
 | `start_date`         | `string` | Start of the range (inclusive), `YYYY-MM-DD`. Cannot be in the future.                                                      | `"2026-02-01"`                           | ✅       |
 | `end_date`           | `string` | End of the range (inclusive), `YYYY-MM-DD`. Must be on or after `start_date`.                                               | `"2026-02-28"`                           | ✅       |
-| `channel_id`         | `string` | Channel/phone UUID. Provide either `channel_id` **or** `phone_number`.                                                       | `"e7190dee-1c64-454d-b785-6ec541a74d4e"` |          |
-| `phone_number`       | `string` | Channel phone number in E.164 format. Used to look up the channel in the workspace.                                         | `"+13867033591"`                         |          |
+| `channel_id`         | `string` | Channel/phone UUID. Provide either `channel_id` **or** `phone_number`.                                                       | `"a1b2c3d4-1111-2222-3333-444455556666"` |          |
+| `phone_number`       | `string` | Channel phone number in E.164 format. Used to look up the channel in the workspace.                                         | `"+12025550123"`                         |          |
 | `channel_type`       | `string` | Disambiguates a phone number shared by multiple channels (e.g. a WhatsApp and an SMS channel on the same number).           | `sms`, `whatsapp`, `messenger`, `instagram`, `line` |          |
 | `notification_email` | `string` | Email address to send the download link to when the export is ready.                                                        | `"agent@example.com"`                    |          |
 
@@ -119,7 +119,7 @@ curl -X 'POST' \
   -H 'Content-Type: application/json' \
   -H 'X-API-Key: <your_api_key>' \
   -d '{
-    "channel_id": "e7190dee-1c64-454d-b785-6ec541a74d4e",
+    "channel_id": "a1b2c3d4-1111-2222-3333-444455556666",
     "start_date": "2026-02-01",
     "end_date": "2026-02-28",
     "notification_email": "agent@example.com"
@@ -135,7 +135,7 @@ curl -X 'POST' \
   -H 'Content-Type: application/json' \
   -H 'X-API-Key: <your_api_key>' \
   -d '{
-    "phone_number": "+13867033591",
+    "phone_number": "+12025550123",
     "channel_type": "whatsapp",
     "start_date": "2026-02-01",
     "end_date": "2026-02-28",
@@ -163,14 +163,14 @@ A phone number that matches multiple channels (`409 Conflict`):
     "message": "Multiple channels match this phone number. Specify channel_type or channel_id.",
     "candidates": [
       {
-        "channel_id": "e7190dee-1c64-454d-b785-6ec541a74d4e",
+        "channel_id": "a1b2c3d4-1111-2222-3333-444455556666",
         "channel_type": "WHATSAPP_BUSINESS_PLATFORM",
-        "name": "SeaX Dev WABP"
+        "name": "WhatsApp Sales"
       },
       {
-        "channel_id": "d701f23b-e01b-4e65-9275-8c9dc463383f",
+        "channel_id": "b2c3d4e5-7777-8888-9999-000011112222",
         "channel_type": "LOCAL",
-        "name": "SeaX Dev Phone"
+        "name": "SMS Support"
       }
     ]
   }
@@ -233,7 +233,7 @@ Response (still running):
 {
   "export_job_id": "79f13adf-f7dc-4744-8ad9-a16b4913e52c",
   "workspace_id": "3fa85f64-5717-4562-b3fc-2c963f66afa6",
-  "channel_id": "d701f23b-e01b-4e65-9275-8c9dc463383f",
+  "channel_id": "b2c3d4e5-7777-8888-9999-000011112222",
   "start_date": "2026-06-01",
   "end_date": "2026-06-10",
   "status": "started",
@@ -250,11 +250,11 @@ Response (finished):
 {
   "export_job_id": "79f13adf-f7dc-4744-8ad9-a16b4913e52c",
   "workspace_id": "3fa85f64-5717-4562-b3fc-2c963f66afa6",
-  "channel_id": "d701f23b-e01b-4e65-9275-8c9dc463383f",
+  "channel_id": "b2c3d4e5-7777-8888-9999-000011112222",
   "start_date": "2026-06-01",
   "end_date": "2026-06-10",
   "status": "finished",
-  "presigned_url": "https://seax-bulksms.s3.amazonaws.com/conversation_exports/.../SeaX_Dev_Phone_2026-06_1c4639da.zip?AWSAccessKeyId=...&Signature=...&Expires=...",
+  "presigned_url": "https://seax-bulksms.s3.amazonaws.com/conversation_exports/.../SMS_Support_2026-06_1c4639da.zip?AWSAccessKeyId=...&Signature=...&Expires=...",
   "presigned_url_expires_at": "2026-06-12T06:50:47.847864",
   "error_message": null,
   "created_time": "2026-06-11T06:50:43.861185"
@@ -264,7 +264,7 @@ Response (finished):
 Download the ZIP from `presigned_url`:
 
 ```bash
-curl -o conversations.zip 'https://seax-bulksms.s3.amazonaws.com/conversation_exports/.../SeaX_Dev_Phone_2026-06_1c4639da.zip?...'
+curl -o conversations.zip 'https://seax-bulksms.s3.amazonaws.com/conversation_exports/.../SMS_Support_2026-06_1c4639da.zip?...'
 ```
 
 ## Export File Format
@@ -272,12 +272,12 @@ curl -o conversations.zip 'https://seax-bulksms.s3.amazonaws.com/conversation_ex
 The export is a ZIP archive containing one CSV file per conversation.
 
 **ZIP file name:** `<channel>_<YYYY-MM>_<id>.zip` — for example
-`SeaX_Dev_Phone_2026-06_1c4639da.zip`, where `<channel>` is the channel name (or
+`SMS_Support_2026-06_1c4639da.zip`, where `<channel>` is the channel name (or
 phone number), `<YYYY-MM>` is taken from the start date, and `<id>` is a short
 unique suffix.
 
 **CSV file name (per conversation):** `<contact>--<created_at>--<channel>.csv` —
-for example `Shao Ho--2026-04-08_032443--SeaX Dev Phone (+13867033591).csv`.
+for example `Jane Doe--2026-04-08_032443--SMS Support (+12025550123).csv`.
 
 **CSV columns:**
 

--- a/content/en/SeaX/export_conversations.md
+++ b/content/en/SeaX/export_conversations.md
@@ -1,0 +1,279 @@
+---
+title: Export Conversations
+linkTitle: Export Conversations
+description:
+  Export a channel's conversation history to a ZIP of per-conversation CSV files
+  using the SeaX API, then poll the export job for a 24-hour download link.
+categories: [API, Conversations, Export]
+tags: [conversations, export, csv, zip, download]
+type: docs
+weight: 9
+---
+
+## Overview
+
+This guide shows how to export the conversations of a single channel over a date
+range. The export is **asynchronous**:
+
+- You trigger an export and immediately receive an `export_job_id`.
+- The job runs in the background, writing **one CSV per conversation** and
+  bundling them into a single **ZIP** file.
+- You poll the job until it finishes to obtain a **presigned download URL**
+  (valid for 24 hours). If you provide a notification email, the link is also
+  emailed to that address.
+
+This guide covers:
+
+- Triggering a conversation export for a channel and date range
+- Identifying the channel by `channel_id` or by `phone_number`
+- Polling the export job and downloading the ZIP
+- The structure of the exported ZIP and CSV files
+
+## Authorization: API Key
+
+Ensure the following are in place:
+
+### **1\. Generate Your API Key**
+
+All APIs require a valid API key issued from your workspace. All requests must
+include a valid API key in the request header (`X-API-Key`).
+
+- Go to **Workspace → API Key** tab.
+
+- Click **Add New Key** and check `Workspace Events Notification` as the scope.
+
+- Copy the key and keep it safe. This key is required in the `X-API-KEY` header
+  for **all requests**.
+
+## How It Works
+
+1. **Trigger** the export with `POST .../export-conversations`. The response
+   returns an `export_job_id` with status `queued`.
+2. **Poll** the job with `GET .../export-conversations/{export_job_id}` until
+   `status` is `finished`.
+3. **Download** the ZIP from the `presigned_url` in the status response. The URL
+   expires 24 hours after the job finishes.
+
+## API Specification
+
+### 1) Trigger a Conversation Export
+
+`POST /api/v1/workspace/{workspace_id}/export-conversations`
+
+Enqueue an export job for one channel over an inclusive date range. The channel
+can be identified either by its `channel_id` (the phone/channel UUID) or by its
+`phone_number` in E.164 format.
+
+Path / Header
+
+| Field          | Type              | Description               | Allowed Values / Example               | Required |
+| -------------- | ----------------- | ------------------------- | -------------------------------------- | -------- |
+| `X-API-Key`    | `string (header)` | Authorization with APIKey | `<your_api_key>`                       | ✅       |
+| `workspace_id` | `string (path)`   | Workspace ID              | `3fa85f64-5717-4562-b3fc-2c963f66afa6` | ✅       |
+
+Request Body: ExportConversationsRequest
+
+| Field                | Type     | Description                                                                                                                 | Allowed Values / Example                 | Required |
+| -------------------- | -------- | --------------------------------------------------------------------------------------------------------------------------- | ---------------------------------------- | -------- |
+| `start_date`         | `string` | Start of the range (inclusive), `YYYY-MM-DD`. Cannot be in the future.                                                      | `"2026-02-01"`                           | ✅       |
+| `end_date`           | `string` | End of the range (inclusive), `YYYY-MM-DD`. Must be on or after `start_date`.                                               | `"2026-02-28"`                           | ✅       |
+| `channel_id`         | `string` | Channel/phone UUID. Provide either `channel_id` **or** `phone_number`.                                                       | `"e7190dee-1c64-454d-b785-6ec541a74d4e"` |          |
+| `phone_number`       | `string` | Channel phone number in E.164 format. Used to look up the channel in the workspace.                                         | `"+13867033591"`                         |          |
+| `channel_type`       | `string` | Disambiguates a phone number shared by multiple channels (e.g. a WhatsApp and an SMS channel on the same number).           | `sms`, `whatsapp`, `messenger`, `instagram`, `line` |          |
+| `notification_email` | `string` | Email address to send the download link to when the export is ready.                                                        | `"agent@example.com"`                    |          |
+
+Notes:
+
+- Provide exactly one of `channel_id` or `phone_number`. If both are omitted the
+  request is rejected.
+- If a `phone_number` matches **more than one** channel, the request returns
+  `409` with the list of matching channels — resend with `channel_type` (or with
+  the exact `channel_id`) to disambiguate.
+- Only one active export per channel and date range is allowed at a time; a
+  duplicate request while one is still running returns `409`.
+
+###### Example
+
+Request:
+
+```bash
+curl -X 'POST' \
+  'https://seax.seasalt.ai/seax-api/api/v1/workspace/3fa85f64-5717-4562-b3fc-2c963f66afa6/export-conversations' \
+  -H 'accept: application/json' \
+  -H 'Content-Type: application/json' \
+  -H 'X-API-Key: <your_api_key>' \
+  -d '{
+    "channel_id": "e7190dee-1c64-454d-b785-6ec541a74d4e",
+    "start_date": "2026-02-01",
+    "end_date": "2026-02-28",
+    "notification_email": "agent@example.com"
+  }'
+```
+
+Identifying the channel by phone number and type instead:
+
+```bash
+curl -X 'POST' \
+  'https://seax.seasalt.ai/seax-api/api/v1/workspace/3fa85f64-5717-4562-b3fc-2c963f66afa6/export-conversations' \
+  -H 'accept: application/json' \
+  -H 'Content-Type: application/json' \
+  -H 'X-API-Key: <your_api_key>' \
+  -d '{
+    "phone_number": "+13867033591",
+    "channel_type": "whatsapp",
+    "start_date": "2026-02-01",
+    "end_date": "2026-02-28",
+    "notification_email": "agent@example.com"
+  }'
+```
+
+Response (`202 Accepted`):
+
+```json
+{
+  "export_job_id": "79f13adf-f7dc-4744-8ad9-a16b4913e52c",
+  "status": "queued",
+  "message": "Export job created. You will be emailed a download link when it is ready."
+}
+```
+
+#### Error responses
+
+A phone number that matches multiple channels (`409 Conflict`):
+
+```json
+{
+  "detail": {
+    "message": "Multiple channels match this phone number. Specify channel_type or channel_id.",
+    "candidates": [
+      {
+        "channel_id": "e7190dee-1c64-454d-b785-6ec541a74d4e",
+        "channel_type": "WHATSAPP_BUSINESS_PLATFORM",
+        "name": "SeaX Dev WABP"
+      },
+      {
+        "channel_id": "d701f23b-e01b-4e65-9275-8c9dc463383f",
+        "channel_type": "LOCAL",
+        "name": "SeaX Dev Phone"
+      }
+    ]
+  }
+}
+```
+
+| Status | Reason                                                                          |
+| ------ | ------------------------------------------------------------------------------- |
+| `400`  | `start_date` is in the future, or the date format is invalid.                   |
+| `404`  | No channel found for the given `channel_id`, or no channel for the phone number. |
+| `409`  | The phone number matches multiple channels, or an export for this channel/date range is already in progress. |
+
+### 2) Get Export Job Status
+
+`GET /api/v1/workspace/{workspace_id}/export-conversations/{export_job_id}`
+
+Poll an export job. While the job is running, `status` is `queued` or `started`
+and `presigned_url` is `null`. When the job is `finished`, `presigned_url`
+contains a download link valid for 24 hours.
+
+Path / Header
+
+| Field           | Type              | Description               | Allowed Values / Example               | Required |
+| --------------- | ----------------- | ------------------------- | -------------------------------------- | -------- |
+| `X-API-Key`     | `string (header)` | Authorization with APIKey | `<your_api_key>`                       | ✅       |
+| `workspace_id`  | `string (path)`   | Workspace ID              | `3fa85f64-5717-4562-b3fc-2c963f66afa6` | ✅       |
+| `export_job_id` | `string (path)`   | The job ID returned by the trigger endpoint | `79f13adf-f7dc-4744-8ad9-a16b4913e52c` | ✅       |
+
+Response fields
+
+| Field                       | Type             | Description                                                                |
+| --------------------------- | ---------------- | -------------------------------------------------------------------------- |
+| `export_job_id`             | `string`         | The export job ID.                                                         |
+| `workspace_id`              | `string`         | Workspace ID.                                                              |
+| `channel_id`                | `string`         | The channel/phone UUID that was exported.                                  |
+| `start_date`                | `string`         | Start of the exported range (`YYYY-MM-DD`).                                |
+| `end_date`                  | `string`         | End of the exported range (`YYYY-MM-DD`).                                  |
+| `status`                    | `string`         | `queued`, `started`, `finished`, or `failed`.                              |
+| `presigned_url`             | `string \| null` | Download URL for the ZIP, available when `status` is `finished`.           |
+| `presigned_url_expires_at`  | `string \| null` | When the download URL expires (24 hours after completion).                 |
+| `error_message`             | `string \| null` | Failure detail when `status` is `failed`.                                  |
+| `created_time`              | `string`         | When the export job was created.                                           |
+
+###### Example
+
+Request:
+
+```bash
+curl -X 'GET' \
+  'https://seax.seasalt.ai/seax-api/api/v1/workspace/3fa85f64-5717-4562-b3fc-2c963f66afa6/export-conversations/79f13adf-f7dc-4744-8ad9-a16b4913e52c' \
+  -H 'accept: application/json' \
+  -H 'X-API-Key: <your_api_key>'
+```
+
+Response (still running):
+
+```json
+{
+  "export_job_id": "79f13adf-f7dc-4744-8ad9-a16b4913e52c",
+  "workspace_id": "3fa85f64-5717-4562-b3fc-2c963f66afa6",
+  "channel_id": "d701f23b-e01b-4e65-9275-8c9dc463383f",
+  "start_date": "2026-06-01",
+  "end_date": "2026-06-10",
+  "status": "started",
+  "presigned_url": null,
+  "presigned_url_expires_at": null,
+  "error_message": null,
+  "created_time": "2026-06-11T06:50:43.861185"
+}
+```
+
+Response (finished):
+
+```json
+{
+  "export_job_id": "79f13adf-f7dc-4744-8ad9-a16b4913e52c",
+  "workspace_id": "3fa85f64-5717-4562-b3fc-2c963f66afa6",
+  "channel_id": "d701f23b-e01b-4e65-9275-8c9dc463383f",
+  "start_date": "2026-06-01",
+  "end_date": "2026-06-10",
+  "status": "finished",
+  "presigned_url": "https://seax-bulksms.s3.amazonaws.com/conversation_exports/.../SeaX_Dev_Phone_2026-06_1c4639da.zip?AWSAccessKeyId=...&Signature=...&Expires=...",
+  "presigned_url_expires_at": "2026-06-12T06:50:47.847864",
+  "error_message": null,
+  "created_time": "2026-06-11T06:50:43.861185"
+}
+```
+
+Download the ZIP from `presigned_url`:
+
+```bash
+curl -o conversations.zip 'https://seax-bulksms.s3.amazonaws.com/conversation_exports/.../SeaX_Dev_Phone_2026-06_1c4639da.zip?...'
+```
+
+## Export File Format
+
+The export is a ZIP archive containing one CSV file per conversation.
+
+**ZIP file name:** `<channel>_<YYYY-MM>_<id>.zip` — for example
+`SeaX_Dev_Phone_2026-06_1c4639da.zip`, where `<channel>` is the channel name (or
+phone number), `<YYYY-MM>` is taken from the start date, and `<id>` is a short
+unique suffix.
+
+**CSV file name (per conversation):** `<contact>--<created_at>--<channel>.csv` —
+for example `Shao Ho--2026-04-08_032443--SeaX Dev Phone (+13867033591).csv`.
+
+**CSV columns:**
+
+| Column            | Description                                                                                             |
+| ----------------- | ------------------------------------------------------------------------------------------------------- |
+| `message_id`      | Unique message ID.                                                                                      |
+| `conversation_id` | ID of the conversation this message belongs to.                                                         |
+| `contact_name`    | The contact's name.                                                                                     |
+| `contact_phone`   | The contact's phone number.                                                                             |
+| `direction`       | `inbound` (from the contact) or `outbound` (from the channel).                                           |
+| `speaker_type`    | Who sent the message: `bot`, `agent`, or `customer`.                                                    |
+| `speaker_name`    | Full name of the speaker — the bot name, the agent's full name, or the contact's name respectively.     |
+| `message_time`    | ISO 8601 timestamp of the message.                                                                      |
+| `message_text`    | The message body.                                                                                       |
+| `media_url`       | Comma-separated media URLs attached to the message, if any.                                             |
+| `status`          | Delivery status of the message.                                                                         |
+| `sender_account`  | The account of the sending agent, if the message was sent by a human agent.                             |


### PR DESCRIPTION
## Summary

Updated the auto-dialer voice campaigns tutorial to document the new campaign-level `message_variables` feature (SeaX PR #5846):

- Restructured into a clear 3-step flow (prepare contacts → write template → create campaign)
- Added campaign-level `message_variables` as the recommended approach for same-value event details
- Included CSV import example with simplified format (just name/phone/labels)
- Documented optional per-contact fields (Step 1b) for when values differ per person
- Clarified precedence rules and reserved keys

This pairs with the backend feature shipped in SeaX PR #5846 and the updated helper scripts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)